### PR TITLE
Fix build script to install web-console dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "packageManager": "pnpm@9.1.0",
   "scripts": {
-    "build": "cd web-console && npm run build",
+    "build": "cd web-console && npm install && npm run build",
     "build:server": "node config/build/esbuild.config.js",
     "start": "node dist/index.js",
     "start:simple": "node dist/index.js",


### PR DESCRIPTION
- Add npm install step before building web-console
- Resolves 'vite: not found' error during Render deployment