### PR TITLE
Fix truncated demo scenario script

### DIFF
--- a/scripts/test-intent-detection-e2e.ts
+++ b/scripts/test-intent-detection-e2e.ts
@@ -1926,4 +1926,18 @@ async function runDemoScenarios() {
       log(chalk.green(`✓ Engagement level: high (4 messages in 30 minutes)`));
       log(chalk.green(`✓ Confidence: ${triggerEvent.args[0].confidence}`));
       log(chalk.green(`✓ Processing time: ${latency3}ms`));
-      log(chalk.green(`✓ Handover created for conversation #
+      log(chalk.green(`✓ Handover created for conversation #${mockConversation.id}`));
+    } else {
+      log(chalk.red(`✗ No intent detected`));
+    }
+
+    // Restore original functions
+    behaviouralMonitor.evaluateEngagement = originalBehaviouralEvaluate;
+    orchestrator.emit = originalEmit;
+
+    return true;
+  } catch (error) {
+    logError('Demo scenarios failed', error);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- close out demo scenario handler in `test-intent-detection-e2e.ts`

## Testing
- `pnpm run lint` *(fails: 22 errors)*
- `pnpm exec tsc --noEmit` *(fails: cannot find type definition file for 'jest')*
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_6855f5f2cf10832196d1fea828ee5208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved log messages for the behavioural intent detection demo to provide clearer and more complete output, including conversation IDs and failure notifications.

- **Chores**
  - Enhanced cleanup by restoring original functions after demo scenarios, ensuring better reliability and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->